### PR TITLE
fix: use UnsafeRelaxedJsonEscaping for readable HTML chars in snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [2.5.0] - 2026-03-13
-
-### Changed
-- Double quotes inside JSON string values are now escaped as `\"` instead of `\u0022` for improved snapshot readability
-
-### Upgrade notes
-- Snapshots containing escaped double quotes will change. Run `UPDATE=true dotnet test` to regenerate snapshots after upgrading. Existing comparisons are unaffected since `JsonNode.Parse` treats both forms identically.
-
 ## [2.4.0] - 2026-03-13
 
 ### Changed
 - JSON encoder switched from `JavaScriptEncoder.Create(UnicodeRanges.All)` to `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` — HTML-sensitive characters (`<`, `>`, `&`) now appear as literals in snapshots instead of Unicode escape sequences (`\u003C`, `\u003E`, `\u0026`)
+- Double quotes inside JSON string values are now escaped as `\"` instead of `\u0022` for improved snapshot readability
 
 ### Upgrade notes
-- Snapshots containing HTML-sensitive characters will change. Run `UPDATE=true dotnet test` to regenerate snapshots after upgrading.
+- Snapshots containing HTML-sensitive characters or escaped double quotes will change. Run `UPDATE=true dotnet test` to regenerate snapshots after upgrading.
 
 ## [2.3.0] - 2026-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.4.0] - 2026-03-13
+
+### Changed
+- JSON encoder switched from `JavaScriptEncoder.Create(UnicodeRanges.All)` to `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` — HTML-sensitive characters (`<`, `>`, `&`) now appear as literals in snapshots instead of Unicode escape sequences (`\u003C`, `\u003E`, `\u0026`)
+
+### Upgrade notes
+- Snapshots containing HTML-sensitive characters will change. Run `UPDATE=true dotnet test` to regenerate snapshots after upgrading.
+
 ## [2.3.0] - 2026-03-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.5.0] - 2026-03-13
+
+### Changed
+- Double quotes inside JSON string values are now escaped as `\"` instead of `\u0022` for improved snapshot readability
+
+### Upgrade notes
+- Snapshots containing escaped double quotes will change. Run `UPDATE=true dotnet test` to regenerate snapshots after upgrading. Existing comparisons are unaffected since `JsonNode.Parse` treats both forms identically.
+
 ## [2.4.0] - 2026-03-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-JestDotnet is a snapshot testing library for .NET, inspired by Jest. It serializes objects to JSON, saves snapshots to files, and compares against them on subsequent runs. Published on NuGet as `JestDotnet` (v2.5.0).
+JestDotnet is a snapshot testing library for .NET, inspired by Jest. It serializes objects to JSON, saves snapshots to files, and compares against them on subsequent runs. Published on NuGet as `JestDotnet` (v2.4.0).
 
 ## Git Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-JestDotnet is a snapshot testing library for .NET, inspired by Jest. It serializes objects to JSON, saves snapshots to files, and compares against them on subsequent runs. Published on NuGet as `JestDotnet` (v2.3.0).
+JestDotnet is a snapshot testing library for .NET, inspired by Jest. It serializes objects to JSON, saves snapshots to files, and compares against them on subsequent runs. Published on NuGet as `JestDotnet` (v2.4.0).
 
 ## Git Workflow
 
@@ -28,7 +28,7 @@ UPDATE=true dotnet test                               # Update snapshots
 - `JestDotnetExtensions` — same methods as extension methods on `object`
 
 **Core pipeline** (`JestDotnet/Core/`):
-- `Serializer` — converts objects to JSON via System.Text.Json (properties sorted alphabetically by default, literal UTF-8 output)
+- `Serializer` — converts objects to JSON via System.Text.Json (properties sorted alphabetically by default, literal UTF-8 output, HTML chars unescaped via `UnsafeRelaxedJsonEscaping`)
 - `SnapshotResolver` — reads/writes `.snap` files in `__snapshots__/` directories, derives path from test class filename + method name + optional hint
 - `SnapshotComparer` — diffs expected vs actual using `SystemTextJson.JsonDiffPatch`
 - `SnapshotUpdater` — orchestrates create/update/fail logic; checks `UPDATE` env var to update snapshots, `CI` env var to prevent snapshot creation in CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-JestDotnet is a snapshot testing library for .NET, inspired by Jest. It serializes objects to JSON, saves snapshots to files, and compares against them on subsequent runs. Published on NuGet as `JestDotnet` (v2.4.0).
+JestDotnet is a snapshot testing library for .NET, inspired by Jest. It serializes objects to JSON, saves snapshots to files, and compares against them on subsequent runs. Published on NuGet as `JestDotnet` (v2.5.0).
 
 ## Git Workflow
 
@@ -28,7 +28,7 @@ UPDATE=true dotnet test                               # Update snapshots
 - `JestDotnetExtensions` — same methods as extension methods on `object`
 
 **Core pipeline** (`JestDotnet/Core/`):
-- `Serializer` — converts objects to JSON via System.Text.Json (properties sorted alphabetically by default, literal UTF-8 output, HTML chars unescaped via `UnsafeRelaxedJsonEscaping`)
+- `Serializer` — converts objects to JSON via System.Text.Json (properties sorted alphabetically by default, literal UTF-8 output, HTML chars unescaped via `UnsafeRelaxedJsonEscaping`, double quotes escaped as `\"` not `\u0022`)
 - `SnapshotResolver` — reads/writes `.snap` files in `__snapshots__/` directories, derives path from test class filename + method name + optional hint
 - `SnapshotComparer` — diffs expected vs actual using `SystemTextJson.JsonDiffPatch`
 - `SnapshotUpdater` — orchestrates create/update/fail logic; checks `UPDATE` env var to update snapshots, `CI` env var to prevent snapshot creation in CI

--- a/JestDotnet/JestDotnet/Core/Serializer.cs
+++ b/JestDotnet/JestDotnet/Core/Serializer.cs
@@ -43,7 +43,7 @@ internal static class Serializer
         using var sortedWriter = new Utf8JsonWriter(sortedStream, writerOptions);
         JsonSerializer.Serialize(sortedWriter, sorted, options);
         sortedWriter.Flush();
-        return Encoding.UTF8.GetString(sortedStream.ToArray());
+        return Encoding.UTF8.GetString(sortedStream.ToArray()).Replace("\\u0022", "\\\"");
     }
 
     internal static void SortJsonNode(JsonNode? node)

--- a/JestDotnet/JestDotnet/Core/Settings/SnapshotSettings.cs
+++ b/JestDotnet/JestDotnet/Core/Settings/SnapshotSettings.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 using System.Text.Json.JsonDiffPatch;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using System.Text.Unicode;
+
 
 namespace JestDotnet.Core.Settings;
 
@@ -60,7 +60,7 @@ public static class SnapshotSettings
         new JsonSerializerOptions
         {
             WriteIndented = true,
-            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             ReferenceHandler = ReferenceHandler.IgnoreCycles,
             TypeInfoResolver = new DefaultJsonTypeInfoResolver
             {

--- a/JestDotnet/JestDotnet/JestDotnet.csproj
+++ b/JestDotnet/JestDotnet/JestDotnet.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0</TargetFrameworks>
-        <Version>2.5.0</Version>
+        <Version>2.4.0</Version>
         <Authors>Tomas Bruckner</Authors>
         <RepositoryUrl>https://github.com/tomasbruckner/jest-dotnet</RepositoryUrl>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/JestDotnet/JestDotnet/JestDotnet.csproj
+++ b/JestDotnet/JestDotnet/JestDotnet.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0</TargetFrameworks>
-        <Version>2.3.0</Version>
+        <Version>2.4.0</Version>
         <Authors>Tomas Bruckner</Authors>
         <RepositoryUrl>https://github.com/tomasbruckner/jest-dotnet</RepositoryUrl>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/JestDotnet/JestDotnet/JestDotnet.csproj
+++ b/JestDotnet/JestDotnet/JestDotnet.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0</TargetFrameworks>
-        <Version>2.4.0</Version>
+        <Version>2.5.0</Version>
         <Authors>Tomas Bruckner</Authors>
         <RepositoryUrl>https://github.com/tomasbruckner/jest-dotnet</RepositoryUrl>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/JestDotnet/XUnitTests/NullAndPrimitiveTests.cs
+++ b/JestDotnet/XUnitTests/NullAndPrimitiveTests.cs
@@ -95,6 +95,12 @@ public class NullAndPrimitiveTests
     }
 
     [Fact]
+    public void StringWithSingleQuotes()
+    {
+        JestAssert.ShouldMatchSnapshot("it's a test");
+    }
+
+    [Fact]
     public void ObjectWithHtmlCharacters()
     {
         JestAssert.ShouldMatchSnapshot(new { comment = "<p>Test & Comment</p>", tag = "<div>" });

--- a/JestDotnet/XUnitTests/NullAndPrimitiveTests.cs
+++ b/JestDotnet/XUnitTests/NullAndPrimitiveTests.cs
@@ -88,6 +88,18 @@ public class NullAndPrimitiveTests
         JestAssert.ShouldMatchSnapshot("he said \"hi\"");
     }
 
+    [Fact]
+    public void StringWithHtmlCharacters()
+    {
+        JestAssert.ShouldMatchSnapshot("<p>Test Comment</p>");
+    }
+
+    [Fact]
+    public void ObjectWithHtmlCharacters()
+    {
+        JestAssert.ShouldMatchSnapshot(new { comment = "<p>Test & Comment</p>", tag = "<div>" });
+    }
+
     // --- Boxed primitives ---
 
     [Fact]

--- a/JestDotnet/XUnitTests/__snapshots__/NullAndPrimitiveTestsObjectWithHtmlCharacters.snap
+++ b/JestDotnet/XUnitTests/__snapshots__/NullAndPrimitiveTestsObjectWithHtmlCharacters.snap
@@ -1,0 +1,4 @@
+{
+  "comment": "<p>Test & Comment</p>",
+  "tag": "<div>"
+}

--- a/JestDotnet/XUnitTests/__snapshots__/NullAndPrimitiveTestsStringWithHtmlCharacters.snap
+++ b/JestDotnet/XUnitTests/__snapshots__/NullAndPrimitiveTestsStringWithHtmlCharacters.snap
@@ -1,0 +1,1 @@
+"<p>Test Comment</p>"

--- a/JestDotnet/XUnitTests/__snapshots__/NullAndPrimitiveTestsStringWithQuotes.snap
+++ b/JestDotnet/XUnitTests/__snapshots__/NullAndPrimitiveTestsStringWithQuotes.snap
@@ -1,1 +1,1 @@
-"he said \u0022hi\u0022"
+"he said \"hi\""

--- a/JestDotnet/XUnitTests/__snapshots__/NullAndPrimitiveTestsStringWithSingleQuotes.snap
+++ b/JestDotnet/XUnitTests/__snapshots__/NullAndPrimitiveTestsStringWithSingleQuotes.snap
@@ -1,0 +1,1 @@
+"it's a test"

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ SnapshotSettings.SnapshotDirectory = SnapshotSettings.DefaultSnapshotDirectory;
 ```
 
 ### Configuring serialization
-For serialization, System.Text.Json is used. By default, snapshots are written with indented formatting, non-ASCII characters are preserved as literal UTF-8, and HTML-sensitive characters (`<`, `>`, `&`) are not escaped (using `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`).
+For serialization, System.Text.Json is used. By default, snapshots are written with indented formatting, non-ASCII characters are preserved as literal UTF-8, HTML-sensitive characters (`<`, `>`, `&`) are not escaped (using `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`), and double quotes inside string values are escaped as `\"` instead of `\u0022`.
 
 If you need to configure it, you can use `SnapshotSettings` class to specify your own
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ SnapshotSettings.SnapshotDirectory = SnapshotSettings.DefaultSnapshotDirectory;
 ```
 
 ### Configuring serialization
-For serialization, System.Text.Json is used. By default, snapshots are written with indented formatting and non-ASCII characters are preserved as literal UTF-8 (using `JavaScriptEncoder.Create(UnicodeRanges.All)`).
+For serialization, System.Text.Json is used. By default, snapshots are written with indented formatting, non-ASCII characters are preserved as literal UTF-8, and HTML-sensitive characters (`<`, `>`, `&`) are not escaped (using `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`).
 
 If you need to configure it, you can use `SnapshotSettings` class to specify your own
 
@@ -277,7 +277,7 @@ JestAssert.ShouldMatchSnapshot(testObject);
 
 Properties are sorted alphabetically by default using ordinal string comparison (`AlphabeticalSortModifier.SortProperties`). This ensures deterministic, culture-independent snapshot output regardless of property declaration order.
 
-> **Note:** When overriding `CreateSerializerOptions`, include `AlphabeticalSortModifier.SortProperties` in your `TypeInfoResolver` modifiers to keep the default sorting behavior. Also include `Encoder = JavaScriptEncoder.Create(UnicodeRanges.All)` to keep non-ASCII characters readable and `ReferenceHandler = ReferenceHandler.IgnoreCycles` to handle circular references.
+> **Note:** When overriding `CreateSerializerOptions`, include `AlphabeticalSortModifier.SortProperties` in your `TypeInfoResolver` modifiers to keep the default sorting behavior. Also include `Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping` to keep non-ASCII and HTML characters readable and `ReferenceHandler = ReferenceHandler.IgnoreCycles` to handle circular references.
 
 #### Circular references
 


### PR DESCRIPTION
HTML-sensitive characters (<, >, &) were being escaped to Unicode sequences (\u003C, \u003E, \u0026) in snapshot files. Since snapshots are never embedded in HTML, readable output is more valuable than HTML-safety escaping. Switch from JavaScriptEncoder.Create(UnicodeRanges.All) to JavaScriptEncoder.UnsafeRelaxedJsonEscaping.

## Summary

<!-- What does this PR do? -->

## Test plan

- [ ] All existing tests pass (`dotnet test` from `JestDotnet/`)
- [ ] Added tests for new functionality (if applicable)
- [ ] Snapshots updated (if applicable)
