### PR TITLE
fix: add contents write permission to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The GitHub release step (softprops/action-gh-release@v2) fails with a 403 because the default GITHUB_TOKEN lacks write access to releases.

## Summary

<!-- What does this PR do? -->

## Test plan

- [ ] All existing tests pass (`dotnet test` from `JestDotnet/`)
- [ ] Added tests for new functionality (if applicable)
- [ ] Snapshots updated (if applicable)
