### PR TITLE
fix: serialize interface/abstract properties using runtime type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.5.0] - 2026-03-14
+
+### Fixed
+- Properties declared as interfaces or abstract types now serialize using the runtime (concrete) type instead of the declared type — e.g., a property typed as `IAnimal` holding a `Dog` now includes `Breed` and `Age` in the snapshot, not just `Name`
+
+### Upgrade notes
+- Snapshots containing interface or abstract type properties will change (additional properties from the concrete type will appear). Run `UPDATE=true dotnet test` to regenerate snapshots after upgrading.
+
 ## [2.4.0] - 2026-03-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-JestDotnet is a snapshot testing library for .NET, inspired by Jest. It serializes objects to JSON, saves snapshots to files, and compares against them on subsequent runs. Published on NuGet as `JestDotnet` (v2.4.0).
+JestDotnet is a snapshot testing library for .NET, inspired by Jest. It serializes objects to JSON, saves snapshots to files, and compares against them on subsequent runs. Published on NuGet as `JestDotnet` (v2.5.0).
 
 ## Git Workflow
 

--- a/JestDotnet/JestDotnet/Core/Settings/RuntimePolymorphicConverter.cs
+++ b/JestDotnet/JestDotnet/Core/Settings/RuntimePolymorphicConverter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace JestDotnet.Core.Settings;
+
+/// <summary>
+///     Converter factory that serializes interface and abstract type properties
+///     using the runtime type instead of the declared type.
+/// </summary>
+internal sealed class RuntimePolymorphicConverterFactory : JsonConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeToConvert.IsInterface || typeToConvert.IsAbstract;
+    }
+
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var converterType = typeof(RuntimePolymorphicConverter<>).MakeGenericType(typeToConvert);
+        return (JsonConverter)Activator.CreateInstance(converterType)!;
+    }
+}
+
+internal sealed class RuntimePolymorphicConverter<T> : JsonConverter<T>
+{
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotSupportedException("Deserialization is not supported.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        JsonSerializer.Serialize(writer, value, value.GetType(), options);
+    }
+}

--- a/JestDotnet/JestDotnet/Core/Settings/SnapshotSettings.cs
+++ b/JestDotnet/JestDotnet/Core/Settings/SnapshotSettings.cs
@@ -66,6 +66,7 @@ public static class SnapshotSettings
             {
                 Modifiers = { AlphabeticalSortModifier.SortProperties }
             },
+            Converters = { new RuntimePolymorphicConverterFactory() },
         };
 
     /// <summary>

--- a/JestDotnet/JestDotnet/JestDotnet.csproj
+++ b/JestDotnet/JestDotnet/JestDotnet.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0</TargetFrameworks>
-        <Version>2.4.0</Version>
+        <Version>2.5.0</Version>
         <Authors>Tomas Bruckner</Authors>
         <RepositoryUrl>https://github.com/tomasbruckner/jest-dotnet</RepositoryUrl>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/JestDotnet/XUnitTests/Helpers/PolymorphicTypes.cs
+++ b/JestDotnet/XUnitTests/Helpers/PolymorphicTypes.cs
@@ -1,0 +1,41 @@
+namespace XUnitTests.Helpers;
+
+public interface IAnimal
+{
+    string Name { get; }
+}
+
+public record Dog : IAnimal
+{
+    public string Name { get; init; } = "";
+    public string Breed { get; init; } = "";
+    public int Age { get; init; }
+}
+
+public record Cat : IAnimal
+{
+    public string Name { get; init; } = "";
+    public bool IsIndoor { get; init; }
+}
+
+public record PetOwner
+{
+    public string OwnerName { get; init; } = "";
+    public IAnimal Pet { get; init; } = null!;
+}
+
+public abstract class Vehicle
+{
+    public string Make { get; set; } = "";
+}
+
+public class Car : Vehicle
+{
+    public int Doors { get; set; }
+}
+
+public record Garage
+{
+    public string Location { get; init; } = "";
+    public Vehicle Vehicle { get; init; } = null!;
+}

--- a/JestDotnet/XUnitTests/PolymorphicSerializationTests.cs
+++ b/JestDotnet/XUnitTests/PolymorphicSerializationTests.cs
@@ -1,0 +1,62 @@
+using JestDotnet;
+using Xunit;
+using XUnitTests.Helpers;
+
+namespace XUnitTests;
+
+public class PolymorphicSerializationTests
+{
+    [Fact]
+    public void ShouldSerializeRuntimeTypeProperties()
+    {
+        var owner = new PetOwner
+        {
+            OwnerName = "John",
+            Pet = new Dog
+            {
+                Name = "Rex",
+                Breed = "Labrador",
+                Age = 5,
+            },
+        };
+
+        JestAssert.ShouldMatchInlineSnapshot(
+            owner,
+            @"
+{
+  ""OwnerName"": ""John"",
+  ""Pet"": {
+    ""Age"": 5,
+    ""Breed"": ""Labrador"",
+    ""Name"": ""Rex""
+  }
+}"
+        );
+    }
+
+    [Fact]
+    public void ShouldSerializeAbstractTypeProperties()
+    {
+        var vehicle = new Garage
+        {
+            Location = "Main Street",
+            Vehicle = new Car
+            {
+                Make = "Toyota",
+                Doors = 4,
+            },
+        };
+
+        JestAssert.ShouldMatchInlineSnapshot(
+            vehicle,
+            @"
+{
+  ""Location"": ""Main Street"",
+  ""Vehicle"": {
+    ""Doors"": 4,
+    ""Make"": ""Toyota""
+  }
+}"
+        );
+    }
+}


### PR DESCRIPTION
STJ serializes properties using the declared type, so a property typed as IAnimal holding a Dog would only include Name, losing Breed and Age. Add RuntimePolymorphicConverterFactory that detects interface/abstract typed properties and serializes them using the concrete runtime type.

## Summary

<!-- What does this PR do? -->

## Test plan

- [ ] All existing tests pass (`dotnet test` from `JestDotnet/`)
- [ ] Added tests for new functionality (if applicable)
- [ ] Snapshots updated (if applicable)
